### PR TITLE
Enable pass thru of options to cheerio

### DIFF
--- a/tasks/inky.js
+++ b/tasks/inky.js
@@ -91,7 +91,7 @@ module.exports = function (grunt) {
                 // Actual Inky processing
                 var i = new Inky(options),
                     input = grunt.file.read(file),
-                    html = cheerio.load(input),
+                    html = cheerio.load(input, options),
                     convertedHtml = i.releaseTheKraken(html);
 
                 fullHtml += convertedHtml;


### PR DESCRIPTION
Added options parameter to cheerio, passing through the options from grunt-inky. Another alternative would be to add a options.cheerio instead of options to delineate what is inky and what is cheerio
